### PR TITLE
Fix code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -30,7 +30,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const usersCollection = db.collection('users');
 
       // Check if the user already exists
-      const existingUser = await usersCollection.findOne({ email });
+      if (typeof email !== 'string') {
+        return res.status(400).json({ error: 'Invalid email format' });
+      }
+      const existingUser = await usersCollection.findOne({ email: { $eq: email } });
       if (existingUser) {
         return res.status(400).json({ error: 'User already exists' });
       }


### PR DESCRIPTION
Fixes [https://github.com/WNT3D1/rectiflexv1/security/code-scanning/3](https://github.com/WNT3D1/rectiflexv1/security/code-scanning/3)

To fix the problem, we need to ensure that the user input is sanitized or validated before being used in the database query. For MongoDB, using the `$eq` operator is a good practice to ensure that the input is treated as a literal value. Additionally, we can validate the input to ensure it is a string and not a query object.

- Modify the query to use the `$eq` operator.
- Add a check to ensure the `email` is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
